### PR TITLE
Switch to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -21,8 +22,28 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
 
       - run: npm install
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: wasm32-wasip1
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Run Changeset
         uses: changesets/action@v1
@@ -31,4 +52,3 @@ jobs:
           publish: npx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why?

npm removed classic/automation tokens in Dec 2025. The current release workflow fails to publish because the granular token requires OTP. Trusted publishing uses OIDC — no token needed, no 2FA prompts.

## Changes

- Added `id-token: write` permission for OIDC authentication
- Added `registry-url` to `setup-node` (required for npm auth)
- Removed `NPM_TOKEN` env var
- Added rust toolchain + cargo cache (needed for the build during publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)